### PR TITLE
bugfix: same data conversion in transmit as in read method

### DIFF
--- a/spi.py
+++ b/spi.py
@@ -421,8 +421,9 @@ class SPI(object):
         Returns:
             List of words read from SPI bus during transfer
         """
+        data = array.array('B', data).tostring()
         length = len(data)
-        transmit_buffer = ctypes.create_string_buffer(str(data))
+        transmit_buffer = ctypes.create_string_buffer(data)
         receive_buffer = ctypes.create_string_buffer(length)
         spi_ioc_transfer = struct.pack(SPI._IOC_TRANSFER_FORMAT,
                                        ctypes.addressof(transmit_buffer),


### PR DESCRIPTION
It took me some time to debug this. Transfer method worked pretty random when list of integers were converted literally to such string: "[1, 2, 3]" not to binary string :)
